### PR TITLE
fix: 🐛 openapi-types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,2 @@
 export { default as generateType } from './src/generate-type';
 export { default as generateTypeFile } from './src/generate-type-file';
-export * from 'openapi-types';

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-prettier": "^5.2.6",
     "git-cz": "^4.9.0",
     "globals": "^16.0.0",
+    "openapi-types": "^12.1.3",
     "prettier": "^3.5.3",
     "rollup": "^3.4.0",
     "rollup-plugin-typescript2": "^0.34.1",
@@ -66,7 +67,6 @@
     "typescript-eslint": "^8.30.1"
   },
   "dependencies": {
-    "openapi-types": "^12.1.3",
     "yaml": "^2.7.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      openapi-types:
-        specifier: ^12.1.3
-        version: 12.1.3
       yaml:
         specifier: ^2.7.1
         version: 2.7.1
@@ -81,6 +78,9 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.0.0
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
       prettier:
         specifier: ^3.5.3
         version: 3.5.3


### PR DESCRIPTION
Give up export the openapi-types, and move it to devdependencies.